### PR TITLE
chore: Add deprecation handler and mark unsupported features as deprecated

### DIFF
--- a/binstar_client/__about__.py
+++ b/binstar_client/__about__.py
@@ -1,7 +1,12 @@
-# -*- coding: utf-8 -*-
+from binstar_client import __version__
+from binstar_client.deprecations import DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated
 
-"""Details about package."""
+deprecated.constant(
+    deprecate_in=DEPRECATE_IN_1_15_0,
+    remove_in=REMOVE_IN_2_0_0,
+    constant="__version__",
+    value=__version__,
+    addendum="Use `binstar_client.__version__` instead",
+)
 
-from ._version import __version__
-
-__all__ = ['__version__']
+del DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -648,5 +648,30 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         return res.json()
 
 
+# Deprecated re-imports from binstar_client.mixins
+deprecated.constant(
+    deprecate_in=DEPRECATE_IN_1_15_0,
+    remove_in=REMOVE_IN_2_0_0,
+    constant="ChannelsMixin",
+    value=ChannelsMixin,
+    addendum="Use `binstar_client.mixins.channels.ChannelsMixin` instead",
+)
+
+deprecated.constant(
+    deprecate_in=DEPRECATE_IN_1_15_0,
+    remove_in=REMOVE_IN_2_0_0,
+    constant="OrgMixin",
+    value=OrgMixin,
+    addendum="Use `binstar_client.mixins.organizations.OrgMixin` instead",
+)
+
+deprecated.constant(
+    deprecate_in=DEPRECATE_IN_1_15_0,
+    remove_in=REMOVE_IN_2_0_0,
+    constant="PackageMixin",
+    value=PackageMixin,
+    addendum="Use `binstar_client.mixins.package.PackageMixin` instead",
+)
+
 # Prevent export of these into the global symbols
 del DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -17,7 +17,18 @@ from ._version import __version__
 from binstar_client.deprecations import DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated
 
 # For backwards compatibility
-from .errors import *
+from .errors import (
+    BinstarError,
+    Unauthorized,
+    Conflict,
+    NotFound,
+    UserError,
+    ServerError,
+    ShowHelp,
+    NoMetadataError,
+    DestinationPathExists,
+    PillowNotInstalled,
+)
 from .mixins.channels import ChannelsMixin
 from .mixins.organizations import OrgMixin
 from .mixins.package import PackageMixin
@@ -672,6 +683,28 @@ deprecated.constant(
     value=PackageMixin,
     addendum="Use `binstar_client.mixins.package.PackageMixin` instead",
 )
+
+# Deprecated re-imports from binstar_client.errors
+
+for name in [
+    "BinstarError",
+    "Unauthorized",
+    "Conflict",
+    "NotFound",
+    "UserError",
+    "ServerError",
+    "ShowHelp",
+    "NoMetadataError",
+    "DestinationPathExists",
+    "PillowNotInstalled",
+]:
+    deprecated.constant(
+        deprecate_in=DEPRECATE_IN_1_15_0,
+        remove_in=REMOVE_IN_2_0_0,
+        constant=name,
+        value=getattr(errors, name),
+        addendum=f"Use `binstar_client.errors.{name}` instead",
+    )
 
 # Prevent export of these into the global symbols
 del DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 
 from . import errors
 from ._version import __version__
+from binstar_client.deprecations import DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated
 
 # For backwards compatibility
 from .errors import *
@@ -105,6 +106,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         except BinstarError:
             return 'password'
 
+    @deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
     def krb_authenticate(self, *args, **kwargs):
         try:
             from requests_kerberos import HTTPKerberosAuth
@@ -644,3 +646,7 @@ class Binstar(OrgMixin, ChannelsMixin, PackageMixin):
         res = self.session.get(url)
         self._check_response(res)
         return res.json()
+
+
+# Prevent export of these into the global symbols
+del DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated

--- a/binstar_client/__init__.py
+++ b/binstar_client/__init__.py
@@ -684,6 +684,36 @@ deprecated.constant(
     addendum="Use `binstar_client.mixins.package.PackageMixin` instead",
 )
 
+# Deprecated re-imports from binstar_client.utils
+deprecated.constant(
+    deprecate_in=DEPRECATE_IN_1_15_0,
+    remove_in=REMOVE_IN_2_0_0,
+    constant="compute_hash",
+    value=compute_hash,
+    addendum="Use `binstar_client.utils.compute_hash` instead",
+)
+deprecated.constant(
+    deprecate_in=DEPRECATE_IN_1_15_0,
+    remove_in=REMOVE_IN_2_0_0,
+    constant="jencode",
+    value=jencode,
+    addendum="Use `binstar_client.utils.jencode` instead",
+)
+deprecated.constant(
+    deprecate_in=DEPRECATE_IN_1_15_0,
+    remove_in=REMOVE_IN_2_0_0,
+    constant="multipart_files_upload",
+    value=multipart_files_upload,
+    addendum="Use `binstar_client.utils.multipart_files_upload` instead",
+)
+deprecated.constant(
+    deprecate_in=DEPRECATE_IN_1_15_0,
+    remove_in=REMOVE_IN_2_0_0,
+    constant="STATUS_CODES",
+    value=STATUS_CODES,
+    addendum="Use `binstar_client.utils.http_codes.STATUS_CODES` instead",
+)
+
 # Deprecated re-imports from binstar_client.errors
 
 for name in [

--- a/binstar_client/deprecations.py
+++ b/binstar_client/deprecations.py
@@ -1,5 +1,10 @@
 """Re-usable helpers for deprecating functionality."""
 
+from anaconda_cli_base.deprecations import DeprecationHandler
+
+from binstar_client import __version__
+
+
 DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED = " ".join(
     [
         "The Projects, Notebooks, and Environments features have been removed.",
@@ -8,3 +13,12 @@ DEPRECATION_MESSAGE_NOTEBOOKS_PROJECTS_ENVIRONMENTS_REMOVED = " ".join(
         "If you have any questions, please contact usercare@anaconda.com.",
     ]
 )
+
+# Store verrsions for which things are deprecated. This gives us a very
+# easy way to find all references, for removal.
+DEPRECATE_IN_1_15_0 = "1.15.0"
+REMOVE_IN_2_0_0 = "2.0.0"
+
+
+# Define a deprecation handler specific to anaconda-client/binstar_client
+deprecated = DeprecationHandler(__version__)

--- a/binstar_client/inspect_package/conda_installer.py
+++ b/binstar_client/inspect_package/conda_installer.py
@@ -3,11 +3,14 @@ from os import path
 
 from ..utils.yaml import yaml_load
 
+from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
+
 logger = logging.getLogger(__name__)
 
 PACKAGE_TYPE = 'installer'
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def is_installer(filename):
     # NOTE: allow
     if not filename.endswith('.sh'):
@@ -31,6 +34,7 @@ def is_installer(filename):
         return True
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def inspect_package(filename, fileobj, *args, **kwarg):
     line = fileobj.readline()
     lines = []

--- a/binstar_client/inspect_package/env.py
+++ b/binstar_client/inspect_package/env.py
@@ -4,7 +4,10 @@ import time
 
 from ..utils.yaml import yaml_load
 
+from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
 
+
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 class EnvInspector:
     def __init__(self, filename, fileobj):
         self._name = None
@@ -36,6 +39,7 @@ class EnvInspector:
         return self._version
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def inspect_env_package(filename, fileobj, *args, **kwargs):
     environment = EnvInspector(filename, fileobj)
 

--- a/binstar_client/inspect_package/ipynb.py
+++ b/binstar_client/inspect_package/ipynb.py
@@ -10,6 +10,10 @@ from ..utils.notebook.data_uri import data_uri_from
 from ..utils.notebook.inflection import parameterize
 
 
+from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
+
+
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def inspect_ipynb_package(filename, fileobj, *args, **kwargs):
     notebook = nbformat.read(fileobj, nbformat.NO_CONVERT)
     summary = notebook.get('metadata', {}).get('summary', 'Jupyter Notebook')

--- a/binstar_client/requests_ext.py
+++ b/binstar_client/requests_ext.py
@@ -9,6 +9,8 @@ import typing
 from requests.auth import AuthBase
 from urllib3.filepost import choose_boundary
 
+from binstar_client.deprecations import DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0, deprecated
+
 __all__ = ['NullAuth', 'encode_multipart_formdata_stream', 'stream_multipart']
 
 logger = logging.getLogger('binstar.requests_ext')
@@ -18,6 +20,7 @@ KeyT = typing.TypeVar('KeyT')
 ValueT = typing.TypeVar('ValueT')
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def iter_fields(
     fields: typing.Union[typing.Mapping[KeyT, ValueT], typing.Iterable[typing.Tuple[KeyT, ValueT]]],
 ) -> typing.Iterator[typing.Tuple[KeyT, ValueT]]:
@@ -46,6 +49,7 @@ class NullAuth(AuthBase):
         return r
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def encode_multipart_formdata_stream(fields, boundary=None):
     """
     Encode a dictionary of ``fields`` using the multipart/form-data MIME format.
@@ -114,6 +118,7 @@ def encode_multipart_formdata_stream(fields, boundary=None):
     return body, content_type
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 class MultiPartIO:
     def __init__(self, body, callback=None):
         self.to_read = body
@@ -166,6 +171,7 @@ class MultiPartIO:
             self._total = self.tell()
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def stream_multipart(data, files=None, callback=None):
     if files:
         fields = chain(iter_fields(data), iter_fields(files))

--- a/binstar_client/utils/notebook/__init__.py
+++ b/binstar_client/utils/notebook/__init__.py
@@ -4,7 +4,10 @@ import nbformat
 
 from ...errors import BinstarError
 
+from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
 
+
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def parse(handle):
     """
     >>> parse("user/notebook")
@@ -24,6 +27,7 @@ def parse(handle):
     raise BinstarError("{} can't be parsed".format(handle))
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def notebook_url(upload_info):
     parsed = urlparse(upload_info['url'])
     if parsed.netloc == 'anaconda.org':
@@ -33,6 +37,7 @@ def notebook_url(upload_info):
     return url
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def has_environment(nb_file):
     if nbformat is None:
         return False

--- a/binstar_client/utils/notebook/data_uri.py
+++ b/binstar_client/utils/notebook/data_uri.py
@@ -13,9 +13,12 @@ except ImportError:
 
 from ...errors import PillowNotInstalled
 
+from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
+
 THUMB_SIZE = (340, 210)
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 class DataURIConverter:
     def __init__(self, location, data=None):
         self.check_pillow_installed()
@@ -67,9 +70,11 @@ class DataURIConverter:
         return data64
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def data_uri_from(location):
     return DataURIConverter(location)()
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def data_uri_from_bytes(data):
     return DataURIConverter(location=None, data=data)()

--- a/binstar_client/utils/notebook/downloader.py
+++ b/binstar_client/utils/notebook/downloader.py
@@ -5,10 +5,12 @@ from time import mktime
 
 from dateutil.parser import parse
 
+from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
 from binstar_client.errors import DestinationPathExists
 from binstar_client.utils.config import PackageType
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 class Downloader:
     """
     Download files from your Anaconda repository.

--- a/binstar_client/utils/notebook/inflection.py
+++ b/binstar_client/utils/notebook/inflection.py
@@ -2,7 +2,10 @@
 import re
 import unicodedata
 
+from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
 
+
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def parameterize(string, separator='-'):
     """
     Replace special characters in a string so that it may be used as part of a
@@ -24,6 +27,7 @@ def parameterize(string, separator='-'):
     return string.lower()
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 def transliterate(string):
     """
     Replace non-ASCII characters with an ASCII approximation. If no

--- a/binstar_client/utils/notebook/uploader.py
+++ b/binstar_client/utils/notebook/uploader.py
@@ -4,12 +4,14 @@ import time
 from os.path import basename
 
 from binstar_client import errors
+from binstar_client.deprecations import deprecated, DEPRECATE_IN_1_15_0, REMOVE_IN_2_0_0
 from .data_uri import data_uri_from
 from .inflection import parameterize
 
 VALID_FORMATS = ['ipynb', 'csv', 'yml', 'yaml', 'json', 'md', 'rst', 'txt']
 
 
+@deprecated(deprecate_in=DEPRECATE_IN_1_15_0, remove_in=REMOVE_IN_2_0_0)
 class Uploader:
     """
     * Find or create a package (project)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ cache_dir = ".cache/pytest"
 filterwarnings = [
   "error",
   "ignore:FileType is deprecated:PendingDeprecationWarning",
+  # Ignore errors from our own internal deprecation warnings
+  "ignore:binstar:DeprecationWarning",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,5 +84,4 @@ line-length = 120
 quote-style = "preserve"
 
 [tool.ruff.lint]
-# TODO: These ignores handle * imports and also unused imports. We should fix them safely.
-ignore = ["F401", "F403", "F405"]
+ignore = ["F401", "F403"]


### PR DESCRIPTION
## Summary

In this PR, we add a deprecation handler and mark unused functions and classes as deprecated. Broadly speaking, these deprecations fall into one of the following categories:

* Support for notebooks, environments, projects, and installers: server-side support for these artifact types was removed from anaconda.org previously
* Global imports in the `binstar_client` namespace: these have been marked as deprecated, with warnings to use their nested equivalents
* Unused utility functions
* Support for legacy authentication methods, such as Kerberos

Users are not anticipated to be affected by these deprecations, however we provide a gradual deprecation to allow for feedback in case any users are unintentionally impacted. The objects marked as deprecated will be removed in `anaconda-client=2.x`.